### PR TITLE
Add server-client config sync

### DIFF
--- a/GreenhouseBuff/GreenhouseBuff/GreenhouseBuffModSystem.cs
+++ b/GreenhouseBuff/GreenhouseBuff/GreenhouseBuffModSystem.cs
@@ -4,6 +4,7 @@ using Vintagestory.API.Server;
 using HarmonyLib;
 
 using GreenhouseBuff.ModNetwork;
+using Newtonsoft.Json;
 
 // config stystem stolen from
 // https://github.com/Foxcapades/vsmod-thrifty-smithing/blob/6f2b6a9b03d2823ee616314f4cd40753572b2bcc/src/main/thrifty/ThriftySmithing.cs#L13
@@ -30,15 +31,18 @@ namespace GreenhouseBuff
                 GreenhouseBuffConfig cfgFromDisk;
                 if ((cfgFromDisk = api.LoadModConfig<GreenhouseBuffConfig>(cfgFileName)) == null)
                 {
+                    this.Mod.Logger.Notification("No config file found, defult one will be generated");
                     api.StoreModConfig(GreenhouseBuffConfig.Loaded, cfgFileName);
                 }
                 else
                 {
+                    this.Mod.Logger.Notification("Config json loaded");
                     GreenhouseBuffConfig.Loaded = cfgFromDisk;
                 }
             }
             catch
             {
+                this.Mod.Logger.Error("Failed to load config JSON, loaded default");
                 api.StoreModConfig(GreenhouseBuffConfig.Loaded, cfgFileName);
             }
 
@@ -48,6 +52,7 @@ namespace GreenhouseBuff
         public override void Start(ICoreAPI api)
         {
             this.api = api;
+            base.Start(api);
 
             // The mod is started once for the server and once for the client.
             // Prevent the patches from being applied by both in the same process.
@@ -55,7 +60,7 @@ namespace GreenhouseBuff
             {
                 harmony = new Harmony(Mod.Info.ModID);
                 harmony.PatchAll(); // Applies all harmony patches
-                this.Mod.Logger.Notification("patches applied");
+                this.Mod.Logger.Notification("Patches applied");
             }
         }
 

--- a/GreenhouseBuff/GreenhouseBuff/GreenhouseBuffModSystem.cs
+++ b/GreenhouseBuff/GreenhouseBuff/GreenhouseBuffModSystem.cs
@@ -1,22 +1,9 @@
 ﻿using Vintagestory.API.Client;
 using Vintagestory.API.Common;
-using Vintagestory.API.Config;
 using Vintagestory.API.Server;
 using HarmonyLib;
-using System.Collections.Generic;
-using System.Reflection.Emit;
-using System;
-using Vintagestory.ClientNative;
-using Vintagestory.API.Datastructures;
-using Vintagestory.API.Common.Entities;
-using Vintagestory.GameContent;
-using System.Text;
-using System.Linq;
 
-using Vintagestory.API.Util;
-using System.Text.Json;
-using System.Runtime.CompilerServices;
-using Cairo;
+using GreenhouseBuff.ModNetwork;
 
 // config stystem stolen from
 // https://github.com/Foxcapades/vsmod-thrifty-smithing/blob/6f2b6a9b03d2823ee616314f4cd40753572b2bcc/src/main/thrifty/ThriftySmithing.cs#L13
@@ -25,89 +12,97 @@ using Cairo;
 
 namespace GreenhouseBuff
 {
-    public class GreenhouseBuffConfig
-    {
-        public int BeehiveTempMod { get; set; }
-        public int BerryBushTempMod { get; set; }
-        public int FarmlandTempMod { get; set; }
-        public int FruitTreeTempMod { get; set; }
-    }
-
     [HarmonyPatch] // Place on any class with harmony patches
     public class GreenhouseBuff : ModSystem
     {
-        private const string ConfigFileName = "GreenhouseBuffConfig.json";
+        private IServerNetworkChannel serverChannel;
 
-        public static ICoreAPI api;
+        private ICoreAPI api;
+
         public Harmony harmony;
 
-        private static GreenhouseBuffConfig loadedConfig;
-        internal static GreenhouseBuffConfig Config => loadedConfig;
+        public override void StartPre(ICoreAPI api)
+        {
+            string cfgFileName = "GreenhouseBuffConfig.json";
+
+            try
+            {
+                GreenhouseBuffConfig cfgFromDisk;
+                if ((cfgFromDisk = api.LoadModConfig<GreenhouseBuffConfig>(cfgFileName)) == null)
+                {
+                    api.StoreModConfig(GreenhouseBuffConfig.Loaded, cfgFileName);
+                }
+                else
+                {
+                    GreenhouseBuffConfig.Loaded = cfgFromDisk;
+                }
+            }
+            catch
+            {
+                api.StoreModConfig(GreenhouseBuffConfig.Loaded, cfgFileName);
+            }
+
+            base.StartPre(api);
+        }
 
         public override void Start(ICoreAPI api)
         {
-            GreenhouseBuff.api = api;
-            loadConfig(api);
+            this.api = api;
+
             // The mod is started once for the server and once for the client.
             // Prevent the patches from being applied by both in the same process.
             if (!Harmony.HasAnyPatches(Mod.Info.ModID))
             {
                 harmony = new Harmony(Mod.Info.ModID);
                 harmony.PatchAll(); // Applies all harmony patches
-                api.Logger.Notification("[Greenhouse Buff] - patches applied");
+                this.Mod.Logger.Notification("patches applied");
             }
         }
 
-        private static void loadConfig(ICoreAPI api)
+        private void OnPlayerJoin(IServerPlayer player)
         {
-            GreenhouseBuffConfig defaultConfig = new GreenhouseBuffConfig
-            {
-                BeehiveTempMod = 0,
-                BerryBushTempMod = 20,
-                FruitTreeTempMod = 20,
-                FarmlandTempMod = 20,
-            };
-
-            try
-            {
-                var configTemp = api.LoadModConfig<string>(ConfigFileName);
-
-                if (configTemp == null)
-            {
-                    api.Logger.Notification("[Greenhouse Buff] - no config file found, defult one will be generated");
-                    loadedConfig = defaultConfig;
-                    api.StoreModConfig(JsonSerializer.Serialize(loadedConfig), ConfigFileName);
-                }
-                else
+            // Send connecting players config settings
+            this.serverChannel.SendPacket(
+                new SyncConfigClientPacket
                 {
-                    var configJSON = JsonSerializer.Deserialize<GreenhouseBuffConfig>(configTemp);
-                    api.Logger.Notification("[Greenhouse Buff] - config jason loaded, content {0}", configTemp);
-                    loadedConfig = configJSON;
-                }
+                    BeehiveTempMod = GreenhouseBuffConfig.Loaded.BeehiveTempMod,
+                    FarmlandTempMod = GreenhouseBuffConfig.Loaded.FarmlandTempMod,
+                    BerryBushTempMod = GreenhouseBuffConfig.Loaded.BerryBushTempMod,
+                    FruitTreeTempMod = GreenhouseBuffConfig.Loaded.FruitTreeTempMod
+                }, player);
         }
-            catch (Exception e)
-            {
-                api.Logger.Notification("[Greenhouse Buff] - failed to load config JSON, loaded defult: {0}", e.Message);
-                loadedConfig = defaultConfig;
-            }
-}
+
+        public override void StartServerSide(ICoreServerAPI sapi)
+        {
+            sapi.Event.PlayerJoin += this.OnPlayerJoin;
+
+            // Create server channel for config data sync
+            this.serverChannel = sapi.Network.RegisterChannel(Mod.Info.ModID)
+                .RegisterMessageType<SyncConfigClientPacket>()
+                .SetMessageHandler<SyncConfigClientPacket>((player, packet) => { });
+        }
+
+        public override void StartClientSide(ICoreClientAPI capi)
+        {
+            // Sync config settings with clients
+            capi.Network.RegisterChannel(Mod.Info.ModID)
+                .RegisterMessageType<SyncConfigClientPacket>()
+                .SetMessageHandler<SyncConfigClientPacket>(p => {
+                    this.Mod.Logger.Event("Received config settings from server");
+                    GreenhouseBuffConfig.Loaded.BeehiveTempMod = p.BeehiveTempMod;
+                    GreenhouseBuffConfig.Loaded.FarmlandTempMod = p.FarmlandTempMod;
+                    GreenhouseBuffConfig.Loaded.BerryBushTempMod = p.BerryBushTempMod;
+                    GreenhouseBuffConfig.Loaded.FruitTreeTempMod = p.FruitTreeTempMod;
+                });
+        }
 
         public override void Dispose()
         {
             harmony?.UnpatchAll(Mod.Info.ModID);
+            if (this.api is ICoreServerAPI sapi)
+            {
+                sapi.Event.PlayerJoin -= this.OnPlayerJoin;
+            }
         }
-
-
-        ////TEST PACH
-        //[HarmonyPrefix]
-        //[HarmonyPatch(typeof(Entity), "ReceiveDamage")]
-        //// Note that the name of the function does not matter
-        //public static void test(Entity __instance, float damage)
-        //{ // For methods, use __instance to obtain the caller object
-        //    api.Logger.Event("{0} is about to take {1} damage!", __instance, damage);
-        //}
-
-
     }
-
 }

--- a/GreenhouseBuff/GreenhouseBuff/GreenhouseBuffModSystem.cs
+++ b/GreenhouseBuff/GreenhouseBuff/GreenhouseBuffModSystem.cs
@@ -4,7 +4,7 @@ using Vintagestory.API.Server;
 using HarmonyLib;
 
 using GreenhouseBuff.ModNetwork;
-using Newtonsoft.Json;
+using GreenhouseBuff.ModConfig;
 
 // config stystem stolen from
 // https://github.com/Foxcapades/vsmod-thrifty-smithing/blob/6f2b6a9b03d2823ee616314f4cd40753572b2bcc/src/main/thrifty/ThriftySmithing.cs#L13

--- a/GreenhouseBuff/GreenhouseBuff/ModConfig/GreenhouseBuffConfig.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModConfig/GreenhouseBuffConfig.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GreenhouseBuff
+{
+    public class GreenhouseBuffConfig
+    {
+        public static GreenhouseBuffConfig Loaded { get; set; } = new GreenhouseBuffConfig();
+
+        public int BeehiveTempMod { get; set; } = 0;
+
+        public int BerryBushTempMod { get; set; } = 20;
+        public int FarmlandTempMod { get; set; } = 20;
+        public int FruitTreeTempMod { get; set; } = 20;
+    }
+}

--- a/GreenhouseBuff/GreenhouseBuff/ModConfig/GreenhouseBuffConfig.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModConfig/GreenhouseBuffConfig.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace GreenhouseBuff
+namespace GreenhouseBuff.ModConfig
 {
     public class GreenhouseBuffConfig
     {

--- a/GreenhouseBuff/GreenhouseBuff/ModNetwork/SyncClientConfigPacket.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModNetwork/SyncClientConfigPacket.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using ProtoBuf;
+
+namespace GreenhouseBuff.ModNetwork
+{
+    [ProtoContract(ImplicitFields = ImplicitFields.AllPublic)]
+    public class SyncConfigClientPacket
+    {
+        public int BeehiveTempMod;
+        public int BerryBushTempMod;
+        public int FarmlandTempMod;
+        public int FruitTreeTempMod;
+    }
+}

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/Beehive.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/Beehive.cs
@@ -6,6 +6,7 @@ using System.Reflection.Emit;
 using Vintagestory.GameContent;
 using System.Linq;
 using Vintagestory.API.Common;
+using GreenhouseBuff.ModConfig;
 
 
 namespace GreenhouseBuff.ModPatches

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/Beehive.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/Beehive.cs
@@ -13,9 +13,6 @@ namespace GreenhouseBuff.ModPatches
     [HarmonyPatch]
     internal class Beehive : ModSystem
     {
-
-        public static float beeTempBonus = GreenhouseBuffConfig.Loaded.BeehiveTempMod;
-
         [HarmonyTranspiler]
         [HarmonyPatch(typeof(BlockEntityBeehive), "TestHarvestable")]
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
@@ -29,7 +26,7 @@ namespace GreenhouseBuff.ModPatches
                     (float)codes[i + 1].operand == 5f && codes[i + 2].opcode == OpCodes.Add)
                 {
                     // Replace it with temp += beeTempBonus
-                    codes[i + 1].operand = beeTempBonus;  // Change the operand to the loaded config value
+                    codes[i + 1].operand = GreenhouseBuffConfig.Loaded.BeehiveTempMod;  // Change the operand to the loaded config value
                 }
             }
 

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/Beehive.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/Beehive.cs
@@ -1,7 +1,5 @@
-﻿
-//DOSENT DO ANYTHING
+﻿//DOESNT DO ANYTHING
 //suspecting bad implemetation in game sas nothing but the code mensiones bees in Greenhouse
-
 using HarmonyLib;
 using System.Collections.Generic;
 using System.Reflection.Emit;
@@ -9,13 +7,14 @@ using Vintagestory.GameContent;
 using System.Linq;
 using Vintagestory.API.Common;
 
-namespace GreenhouseBuff
+
+namespace GreenhouseBuff.ModPatches
 {
     [HarmonyPatch]
     internal class Beehive : ModSystem
     {
 
-        public static float beeTempBonus = GreenhouseBuff.Config.BeehiveTempMod;
+        public static float beeTempBonus = GreenhouseBuffConfig.Loaded.BeehiveTempMod;
 
         [HarmonyTranspiler]
         [HarmonyPatch(typeof(BlockEntityBeehive), "TestHarvestable")]

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/Beehive.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/Beehive.cs
@@ -26,7 +26,7 @@ namespace GreenhouseBuff.ModPatches
                     (float)codes[i + 1].operand == 5f && codes[i + 2].opcode == OpCodes.Add)
                 {
                     // Replace it with temp += beeTempBonus
-                    codes[i + 1].operand = GreenhouseBuffConfig.Loaded.BeehiveTempMod;  // Change the operand to the loaded config value
+                    codes[i + 1].operand = (float)GreenhouseBuffConfig.Loaded.BeehiveTempMod;  // Change the operand to the loaded config value
                 }
             }
 

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/BerryBush.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/BerryBush.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.GameContent;
+using GreenhouseBuff.ModConfig;
 
 
 namespace GreenhouseBuff.ModPatches

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/BerryBush.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/BerryBush.cs
@@ -13,8 +13,6 @@ namespace GreenhouseBuff.ModPatches
     [HarmonyPatch]
     internal class BerryBush : ModSystem
     {
-        public static float bushTempBonus = GreenhouseBuffConfig.Loaded.BerryBushTempMod;
-
         //WORKS ?
         //A B TEST with and wiwout mod on 80 - works
         [HarmonyTranspiler]
@@ -30,7 +28,7 @@ namespace GreenhouseBuff.ModPatches
                     (float)codes[i + 1].operand == 5f && codes[i + 2].opcode == OpCodes.Add)
                 {
                     // Replace it with temperature += bushTempBonus
-                    codes[i + 1].operand = bushTempBonus;  // Change the operand to the loaded config value
+                    codes[i + 1].operand = GreenhouseBuffConfig.Loaded.BerryBushTempMod;  // Change the operand to the loaded config value
                 }
             }
 
@@ -45,7 +43,7 @@ namespace GreenhouseBuff.ModPatches
 
             // Replace the '5' in the greenhouse temp bonus string
             string originalString = Lang.Get("greenhousetempbonus");
-            string modifiedString = originalString.Replace("5", bushTempBonus.ToString());
+            string modifiedString = originalString.Replace("5", GreenhouseBuffConfig.Loaded.BerryBushTempMod.ToString());
 
             // Modify the description
             if (sb.ToString().Contains(originalString))

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/BerryBush.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/BerryBush.cs
@@ -7,12 +7,13 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.GameContent;
 
-namespace GreenhouseBuff
+
+namespace GreenhouseBuff.ModPatches
 {
     [HarmonyPatch]
     internal class BerryBush : ModSystem
     {
-        public static float bushTempBonus = GreenhouseBuff.Config.BerryBushTempMod;
+        public static float bushTempBonus = GreenhouseBuffConfig.Loaded.BerryBushTempMod;
 
         //WORKS ?
         //A B TEST with and wiwout mod on 80 - works

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/BerryBush.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/BerryBush.cs
@@ -28,7 +28,7 @@ namespace GreenhouseBuff.ModPatches
                     (float)codes[i + 1].operand == 5f && codes[i + 2].opcode == OpCodes.Add)
                 {
                     // Replace it with temperature += bushTempBonus
-                    codes[i + 1].operand = GreenhouseBuffConfig.Loaded.BerryBushTempMod;  // Change the operand to the loaded config value
+                    codes[i + 1].operand = (float)GreenhouseBuffConfig.Loaded.BerryBushTempMod;  // Change the operand to the loaded config value
                 }
             }
 

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/Farmland.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/Farmland.cs
@@ -15,8 +15,6 @@ namespace GreenhouseBuff.ModPatches
     {
         //20 grows
         //15 dies
-        
-        public static float farmlandTempBonus = GreenhouseBuffConfig.Loaded.FarmlandTempMod;
 
         //WORKS
         //A B TEST with and wiwout mod - works
@@ -34,7 +32,7 @@ namespace GreenhouseBuff.ModPatches
                     (float)codes[i + 1].operand == 5f && codes[i + 2].opcode == OpCodes.Add)
                 {
                     // Replace it with conds.Temperature += farmlandTempBonus
-                    codes[i + 1].operand = farmlandTempBonus;  // Change the operand to the loaded config value
+                    codes[i + 1].operand = GreenhouseBuffConfig.Loaded.FarmlandTempMod;  // Change the operand to the loaded config value
                 }
             }
 
@@ -49,7 +47,7 @@ namespace GreenhouseBuff.ModPatches
 
             // Replace the '5' in the greenhouse temp bonus string
             string originalString = Lang.Get("greenhousetempbonus");
-            string modifiedString = originalString.Replace("5", farmlandTempBonus.ToString());
+            string modifiedString = originalString.Replace("5", GreenhouseBuffConfig.Loaded.FarmlandTempMod.ToString());
 
             // Modify the description
             if (dsc.ToString().Contains(originalString))

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/Farmland.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/Farmland.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Vintagestory.API.Config;
 using Vintagestory.GameContent;
 using Vintagestory.API.Common;
+using GreenhouseBuff.ModConfig;
 
 
 namespace GreenhouseBuff.ModPatches

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/Farmland.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/Farmland.cs
@@ -8,8 +8,7 @@ using Vintagestory.GameContent;
 using Vintagestory.API.Common;
 
 
-
-namespace GreenhouseBuff
+namespace GreenhouseBuff.ModPatches
 {
     [HarmonyPatch]
     internal class Farmland : ModSystem
@@ -17,7 +16,7 @@ namespace GreenhouseBuff
         //20 grows
         //15 dies
         
-        public static float farmlandTempBonus = GreenhouseBuff.Config.FarmlandTempMod;
+        public static float farmlandTempBonus = GreenhouseBuffConfig.Loaded.FarmlandTempMod;
 
         //WORKS
         //A B TEST with and wiwout mod - works

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/Farmland.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/Farmland.cs
@@ -32,7 +32,7 @@ namespace GreenhouseBuff.ModPatches
                     (float)codes[i + 1].operand == 5f && codes[i + 2].opcode == OpCodes.Add)
                 {
                     // Replace it with conds.Temperature += farmlandTempBonus
-                    codes[i + 1].operand = GreenhouseBuffConfig.Loaded.FarmlandTempMod;  // Change the operand to the loaded config value
+                    codes[i + 1].operand = (float)GreenhouseBuffConfig.Loaded.FarmlandTempMod;  // Change the operand to the loaded config value
                 }
             }
 

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/FruitTree.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/FruitTree.cs
@@ -3,7 +3,7 @@ using Vintagestory.API.Common;
 using Vintagestory.GameContent;
 
 
-namespace GreenhouseBuff
+namespace GreenhouseBuff.ModPatches
 {
     //WORKKS
     //A B TEST with and wiwout mod - works
@@ -12,7 +12,7 @@ namespace GreenhouseBuff
     internal class FruitTree : ModSystem
     {
 
-        public static float treeTempBonus = GreenhouseBuff.Config.FruitTreeTempMod;
+        public static float treeTempBonus = GreenhouseBuffConfig.Loaded.FruitTreeTempMod;
 
         [HarmonyPostfix]
         [HarmonyPatch(typeof(FruitTreeRootBH), "getGreenhouseTempBonus")]

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/FruitTree.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/FruitTree.cs
@@ -19,7 +19,7 @@ namespace GreenhouseBuff.ModPatches
             // Check if the original return value is 5 and modify it to 10
             if (__result == 5)
             {
-                __result = GreenhouseBuffConfig.Loaded.FruitTreeTempMod;
+                __result = (float)GreenhouseBuffConfig.Loaded.FruitTreeTempMod;
             }
         }
     }

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/FruitTree.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/FruitTree.cs
@@ -12,8 +12,6 @@ namespace GreenhouseBuff.ModPatches
     internal class FruitTree : ModSystem
     {
 
-        public static float treeTempBonus = GreenhouseBuffConfig.Loaded.FruitTreeTempMod;
-
         [HarmonyPostfix]
         [HarmonyPatch(typeof(FruitTreeRootBH), "getGreenhouseTempBonus")]
         public static void tree(ref float __result)
@@ -21,7 +19,7 @@ namespace GreenhouseBuff.ModPatches
             // Check if the original return value is 5 and modify it to 10
             if (__result == 5)
             {
-                __result = treeTempBonus;
+                __result = GreenhouseBuffConfig.Loaded.FruitTreeTempMod;
             }
         }
     }

--- a/GreenhouseBuff/GreenhouseBuff/ModPatches/FruitTree.cs
+++ b/GreenhouseBuff/GreenhouseBuff/ModPatches/FruitTree.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using Vintagestory.API.Common;
 using Vintagestory.GameContent;
+using GreenhouseBuff.ModConfig;
 
 
 namespace GreenhouseBuff.ModPatches

--- a/GreenhouseBuff/GreenhouseBuff/modinfo.json
+++ b/GreenhouseBuff/GreenhouseBuff/modinfo.json
@@ -3,7 +3,7 @@
   "modid": "greenhousebuff",
   "name": "GreenhouseBuff",
   "authors": [ "Kaktur09" ],
-  "description": "Mod that increses the buff from greenhouses.",
-  "version": "1.1.0",
-  "dependencies": { "game": "1.19.8" }
+  "description": "Mod that increases the buff from greenhouses.",
+  "version": "1.2.0-a",
+  "dependencies": { "game": "*" }
 }

--- a/GreenhouseBuff/GreenhouseBuff/modinfo.json
+++ b/GreenhouseBuff/GreenhouseBuff/modinfo.json
@@ -4,6 +4,6 @@
   "name": "GreenhouseBuff",
   "authors": [ "Kaktur09" ],
   "description": "Mod that increases the buff from greenhouses.",
-  "version": "1.2.0-a",
+  "version": "1.2.0",
   "dependencies": { "game": "*" }
 }


### PR DESCRIPTION
* Refactor namespaces and config
* Add packet system for config
* Change config access for each patch
* Removed unused imports
* Increment mod version to 1.2.0; change game required version to `"*"`

Tested on a private server with configs set differently than defaults (10 instead of 20). Values show properly on client which still has defaults set in config file, so network sync'd config values (server->client) are working.